### PR TITLE
Premerging Upstream Cumulus PR #772 (mock XCM)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,6 +1796,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
+ "sp-storage",
  "sp-trie",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "beefy-primitives",
  "fnv",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "beefy-gadget",
  "beefy-primitives",
@@ -510,12 +510,12 @@ dependencies = [
 [[package]]
 name = "beefy-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 
 [[package]]
 name = "beefy-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "bp-message-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bp-runtime",
  "frame-support",
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bitvec 0.20.1",
  "bp-runtime",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "bp-rialto"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -783,7 +783,7 @@ dependencies = [
 [[package]]
 name = "bp-rococo"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "frame-support",
  "hash-db",
@@ -818,7 +818,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bp-header-chain",
  "ed25519-dalek",
@@ -833,7 +833,7 @@ dependencies = [
 [[package]]
 name = "bp-wococo"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bp-message-dispatch",
  "bp-messages",
@@ -2444,7 +2444,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#afd572f208b25312f984987b7bb752e71fbf86d7"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "Inflector",
  "chrono",
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2522,7 +2522,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2550,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -2589,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.1.0",
@@ -2601,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2611,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "log",
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2652,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "sp-api",
@@ -3604,7 +3604,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "beefy-primitives",
  "bitvec 0.20.1",
@@ -4574,7 +4574,7 @@ dependencies = [
 [[package]]
 name = "metered-channel"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -4864,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "node-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
@@ -5058,7 +5058,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5072,7 +5072,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5088,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5119,7 +5119,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5143,7 +5143,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5178,7 +5178,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "beefy-primitives",
  "frame-support",
@@ -5194,7 +5194,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "beefy-merkle-tree",
  "beefy-primitives",
@@ -5219,7 +5219,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5237,7 +5237,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bp-message-dispatch",
  "bp-runtime",
@@ -5254,7 +5254,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -5276,7 +5276,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bitvec 0.20.1",
  "bp-message-dispatch",
@@ -5324,7 +5324,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5341,7 +5341,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5357,7 +5357,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5381,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5399,7 +5399,7 @@ dependencies = [
 [[package]]
 name = "pallet-gilt"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5414,7 +5414,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5437,7 +5437,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5453,7 +5453,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5473,7 +5473,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5490,7 +5490,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5507,7 +5507,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -5525,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5541,7 +5541,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5558,7 +5558,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5573,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5587,7 +5587,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5604,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5627,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5642,7 +5642,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5656,7 +5656,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5670,7 +5670,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5686,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5707,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5723,7 +5723,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5737,7 +5737,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5760,7 +5760,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -5771,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -5780,7 +5780,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5809,7 +5809,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5827,7 +5827,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5846,7 +5846,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5863,7 +5863,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5891,7 +5891,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5908,7 +5908,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5922,7 +5922,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5938,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5953,7 +5953,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5971,7 +5971,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6491,7 +6491,7 @@ checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "futures 0.3.17",
  "polkadot-node-network-protocol",
@@ -6505,7 +6505,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "futures 0.3.17",
  "polkadot-node-network-protocol",
@@ -6518,7 +6518,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -6540,7 +6540,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "futures 0.3.17",
  "lru 0.7.0",
@@ -6560,7 +6560,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "frame-benchmarking-cli",
  "futures 0.3.17",
@@ -6580,7 +6580,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "beefy-primitives",
  "frame-benchmarking",
@@ -6678,7 +6678,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "always-assert",
  "derive_more",
@@ -6699,7 +6699,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -6712,7 +6712,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -6734,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -6748,7 +6748,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -6768,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -6787,7 +6787,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "futures 0.3.17",
  "parity-scale-codec",
@@ -6805,7 +6805,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bitvec 0.20.1",
  "derive_more",
@@ -6833,7 +6833,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bitvec 0.20.1",
  "futures 0.3.17",
@@ -6853,7 +6853,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bitvec 0.20.1",
  "futures 0.3.17",
@@ -6871,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "futures 0.3.17",
  "polkadot-node-subsystem",
@@ -6886,7 +6886,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -6904,7 +6904,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "futures 0.3.17",
  "polkadot-node-subsystem",
@@ -6919,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -6936,7 +6936,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bitvec 0.20.1",
  "derive_more",
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-participation"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "futures 0.3.17",
  "polkadot-node-primitives",
@@ -6968,7 +6968,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -6985,7 +6985,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bitvec 0.20.1",
  "futures 0.3.17",
@@ -7000,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -7031,7 +7031,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "futures 0.3.17",
  "memory-lru",
@@ -7049,7 +7049,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -7067,7 +7067,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -7078,7 +7078,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7096,7 +7096,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bounded-vec",
  "futures 0.3.17",
@@ -7118,7 +7118,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -7128,7 +7128,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -7146,7 +7146,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -7165,7 +7165,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7192,7 +7192,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -7213,7 +7213,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer-gen"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -7230,7 +7230,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer-gen-proc-macro"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -7241,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -7258,7 +7258,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bitvec 0.20.1",
  "frame-system",
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -7319,7 +7319,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "beefy-primitives",
  "bitvec 0.20.1",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "beefy-primitives",
  "bitvec 0.20.1",
@@ -7443,7 +7443,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "bitflags",
  "bitvec 0.20.1",
@@ -7482,7 +7482,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -7580,7 +7580,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "arrayvec 0.5.2",
  "derive_more",
@@ -7601,7 +7601,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -7611,7 +7611,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-client"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-subsystem",
@@ -7636,7 +7636,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "beefy-primitives",
  "bitvec 0.20.1",
@@ -7697,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -8291,7 +8291,7 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#afd572f208b25312f984987b7bb752e71fbf86d7"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "env_logger 0.9.0",
  "jsonrpsee-proc-macros",
@@ -8420,7 +8420,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "beefy-primitives",
  "bp-messages",
@@ -8609,7 +8609,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "log",
  "sp-core",
@@ -8620,7 +8620,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8647,7 +8647,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -8670,7 +8670,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -8686,7 +8686,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8702,7 +8702,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -8713,7 +8713,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -8751,7 +8751,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "fnv",
  "futures 0.3.17",
@@ -8779,7 +8779,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -8804,7 +8804,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -8828,7 +8828,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#afd572f208b25312f984987b7bb752e71fbf86d7"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8857,7 +8857,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8900,7 +8900,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -8924,7 +8924,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -8937,7 +8937,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "sc-client-api",
  "sp-authorship",
@@ -8974,7 +8974,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "lazy_static",
  "libsecp256k1 0.6.0",
@@ -9000,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "derive_more",
  "environmental",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9034,7 +9034,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -9052,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -9089,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -9113,7 +9113,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.17",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -9145,7 +9145,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -9163,7 +9163,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-std",
  "async-trait",
@@ -9214,7 +9214,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -9230,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -9257,7 +9257,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "futures 0.3.17",
  "libp2p",
@@ -9270,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "futures 0.3.17",
  "hash-db",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "futures 0.3.17",
  "jsonrpc-core",
@@ -9335,7 +9335,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "futures 0.3.17",
  "jsonrpc-core",
@@ -9352,7 +9352,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "directories",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9431,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -9453,7 +9453,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "chrono",
  "futures 0.3.17",
@@ -9471,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -9501,7 +9501,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -9512,7 +9512,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "futures 0.3.17",
  "intervalier",
@@ -9539,7 +9539,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -9553,7 +9553,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -9901,7 +9901,7 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -10004,7 +10004,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "hash-db",
  "log",
@@ -10021,7 +10021,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.1.0",
@@ -10033,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10046,7 +10046,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -10061,7 +10061,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10086,7 +10086,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10098,7 +10098,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "futures 0.3.17",
  "log",
@@ -10116,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -10135,7 +10135,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10153,7 +10153,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "merlin",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10187,7 +10187,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -10199,7 +10199,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10264,7 +10264,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10275,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10293,7 +10293,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10307,7 +10307,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "futures 0.3.17",
  "hash-db",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -10342,7 +10342,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -10359,7 +10359,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "zstd",
 ]
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -10393,7 +10393,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -10403,7 +10403,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "backtrace",
 ]
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -10421,7 +10421,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -10443,7 +10443,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10460,7 +10460,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.0",
@@ -10472,7 +10472,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "serde",
  "serde_json",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10495,7 +10495,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10506,7 +10506,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "hash-db",
  "log",
@@ -10529,12 +10529,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10547,7 +10547,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "log",
  "sp-core",
@@ -10560,7 +10560,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -10588,7 +10588,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10597,7 +10597,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "log",
@@ -10613,7 +10613,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -10628,7 +10628,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10644,7 +10644,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -10655,7 +10655,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10971,7 +10971,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#afd572f208b25312f984987b7bb752e71fbf86d7"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "platforms",
 ]
@@ -10979,7 +10979,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.17",
@@ -11001,7 +11001,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-std",
  "derive_more",
@@ -11015,7 +11015,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -11042,7 +11042,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "futures 0.3.17",
  "substrate-test-utils-derive",
@@ -11052,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -11063,7 +11063,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#ce1c7c2c0c9bab718e6b04c9c65141e253e71861"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "ansi_term 0.12.1",
  "build-helper",
@@ -11517,7 +11517,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.12#afd572f208b25312f984987b7bb752e71fbf86d7"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.12#16d14662d4337231e9da7277a7b11cc204d84a34"
 dependencies = [
  "jsonrpsee-ws-client",
  "log",
@@ -12093,7 +12093,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "beefy-primitives",
  "bitvec 0.20.1",
@@ -12338,7 +12338,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
@@ -12351,7 +12351,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12371,7 +12371,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.12"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -12389,7 +12389,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.12#ea6b0493a345b9f57b08180fb20521deca5b72d6"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.12#b8090ea5d9ebe9296b89a54db9828c3d4fdb9b95"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,9 +1639,9 @@ dependencies = [
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
 dependencies = [
- "cumulus-pallet-parachain-system-proc-macro",
- "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-pallet-parachain-system-proc-macro 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
  "cumulus-test-client",
  "cumulus-test-relay-sproof-builder 0.1.0",
  "environmental",
@@ -1673,6 +1673,17 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
+dependencies = [
+ "proc-macro-crate 1.1.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cumulus-pallet-parachain-system-proc-macro"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12#ea2b71e0f6030abdb5dfc67bb53af111d336b6f2"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -1802,6 +1813,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-primitives-parachain-inherent"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12#ea2b71e0f6030abdb5dfc67bb53af111d336b6f2"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "parity-scale-codec",
+ "polkadot-client",
+ "sc-client-api",
+ "scale-info",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
+ "tracing",
+]
+
+[[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
 dependencies = [
@@ -1839,7 +1872,7 @@ name = "cumulus-test-client"
 version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-parachain-inherent 0.1.0",
  "cumulus-test-relay-sproof-builder 0.1.0",
  "cumulus-test-runtime",
  "cumulus-test-service",
@@ -1971,7 +2004,7 @@ dependencies = [
  "cumulus-client-network",
  "cumulus-client-service",
  "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-parachain-inherent 0.1.0",
  "cumulus-test-relay-validation-worker-provider",
  "cumulus-test-runtime",
  "cumulus-test-runtime-upgrade",
@@ -6039,7 +6072,7 @@ dependencies = [
  "cumulus-client-network",
  "cumulus-client-service",
  "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-parachain-inherent 0.1.0",
  "derive_more",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -6651,7 +6684,7 @@ dependencies = [
  "cumulus-client-network",
  "cumulus-client-service",
  "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-parachain-inherent 0.1.0",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "futures 0.3.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.11#e0ef78f83dd9d1167d6fc520598f53cdcac5a1e1"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12#ea2b71e0f6030abdb5dfc67bb53af111d336b6f2"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1784,8 +1784,8 @@ name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
  "parity-scale-codec",
  "polkadot-client",
  "sc-client-api",
@@ -1880,9 +1880,9 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.11#e0ef78f83dd9d1167d6fc520598f53cdcac5a1e1"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12#ea2b71e0f6030abdb5dfc67bb53af111d336b6f2"
 dependencies = [
- "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.11)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
  "cumulus-client-network",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-test-client",
  "cumulus-test-runtime",
  "futures 0.3.17",
@@ -1444,7 +1444,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "futures 0.3.17",
  "parity-scale-codec",
  "polkadot-client",
@@ -1495,7 +1495,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "futures 0.3.17",
  "parking_lot 0.10.2",
  "polkadot-client",
@@ -1516,7 +1516,7 @@ dependencies = [
 name = "cumulus-client-network"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-test-service",
  "derive_more",
  "futures 0.3.17",
@@ -1547,7 +1547,7 @@ dependencies = [
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-test-service",
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -1577,7 +1577,7 @@ dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-pov-recovery",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "polkadot-overseer",
@@ -1620,7 +1620,7 @@ dependencies = [
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "frame-support",
  "frame-system",
  "log",
@@ -1640,10 +1640,10 @@ name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-parachain-inherent",
  "cumulus-test-client",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-test-relay-sproof-builder 0.1.0",
  "environmental",
  "frame-support",
  "frame-system",
@@ -1696,7 +1696,7 @@ dependencies = [
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -1713,7 +1713,7 @@ name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "frame-support",
  "frame-system",
  "log",
@@ -1735,7 +1735,7 @@ name = "cumulus-ping"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-xcm",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -1749,6 +1749,23 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
+ "sp-trie",
+]
+
+[[package]]
+name = "cumulus-primitives-core"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.11#e0ef78f83dd9d1167d6fc520598f53cdcac5a1e1"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1787,9 +1804,9 @@ dependencies = [
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-test-client",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-test-relay-sproof-builder 0.1.0",
  "futures 0.3.17",
  "parity-scale-codec",
  "sp-consensus",
@@ -1804,7 +1821,7 @@ dependencies = [
 name = "cumulus-primitives-utility"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "frame-support",
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -1820,9 +1837,9 @@ dependencies = [
 name = "cumulus-test-client"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-parachain-inherent",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-test-relay-sproof-builder 0.1.0",
  "cumulus-test-runtime",
  "cumulus-test-service",
  "frame-system",
@@ -1851,7 +1868,20 @@ dependencies = [
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+]
+
+[[package]]
+name = "cumulus-test-relay-sproof-builder"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.11#e0ef78f83dd9d1167d6fc520598f53cdcac5a1e1"
+dependencies = [
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.11)",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-runtime",
@@ -1871,7 +1901,7 @@ name = "cumulus-test-runtime"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "frame-executive",
  "frame-support",
@@ -1903,7 +1933,7 @@ name = "cumulus-test-runtime-upgrade"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "frame-executive",
  "frame-support",
@@ -1939,7 +1969,7 @@ dependencies = [
  "cumulus-client-consensus-relay-chain",
  "cumulus-client-network",
  "cumulus-client-service",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-parachain-inherent",
  "cumulus-test-relay-validation-worker-provider",
  "cumulus-test-runtime",
@@ -5989,7 +6019,7 @@ dependencies = [
 name = "parachain-info"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -6007,7 +6037,7 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-client-service",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-parachain-inherent",
  "derive_more",
  "frame-benchmarking",
@@ -6067,7 +6097,7 @@ dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",
@@ -6619,7 +6649,7 @@ dependencies = [
  "cumulus-client-consensus-relay-chain",
  "cumulus-client-network",
  "cumulus-client-service",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-parachain-inherent",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -8376,7 +8406,7 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-ping",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-executive",
@@ -9822,7 +9852,7 @@ dependencies = [
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcm",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-utility",
  "frame-executive",
  "frame-support",
@@ -10700,7 +10730,7 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-ping",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",
@@ -10766,7 +10796,7 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-ping",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",
@@ -12185,7 +12215,7 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-ping",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 structopt = "0.3.3"
 
 # Substrate dependencies
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sc-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-service = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }

--- a/client/collator/Cargo.toml
+++ b/client/collator/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2018"
 
 [dependencies]
 # Substrate dependencies
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot dependencies
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-node-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-overseer = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-node-subsystem = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-node-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-overseer = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-node-subsystem = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-client-network = { path = "../network" }
@@ -31,15 +31,15 @@ tracing = "0.1.25"
 
 [dev-dependencies]
 # Polkadot dependencies
-polkadot-node-subsystem-test-helpers = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-node-subsystem-test-helpers = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-test-runtime = { path = "../../test/runtime" }
 cumulus-test-client = { path = "../../test/client" }
 # Substrate dependencies
 
-sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sp-state-machine = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Other dependencies
 async-trait = "0.1.42"

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -7,25 +7,25 @@ edition = "2018"
 
 [dependencies]
 # Substrate dependencies
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-consensus-slots = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus-aura = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-application-crypto = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-consensus-aura = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-consensus-slots = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-telemetry = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+substrate-prometheus-endpoint = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot dependencies
-polkadot-client = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-client = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-client-consensus-common = { path = "../common" }

--- a/client/consensus/common/Cargo.toml
+++ b/client/consensus/common/Cargo.toml
@@ -7,16 +7,16 @@ edition = "2018"
 
 [dependencies]
 # Substrate deps
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sc-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-trie = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot deps
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Other deps
 futures = { version = "0.3.8", features = ["compat"] }
@@ -27,7 +27,7 @@ dyn-clone = "1.0.4"
 
 [dev-dependencies]
 # Substrate deps
-sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sp-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 # Cumulus dependencies
 cumulus-test-client = { path = "../../../test/client" }
 # Other deps

--- a/client/consensus/relay-chain/Cargo.toml
+++ b/client/consensus/relay-chain/Cargo.toml
@@ -7,19 +7,19 @@ edition = "2018"
 
 [dependencies]
 # Substrate deps
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+substrate-prometheus-endpoint = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot dependencies
-polkadot-client = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-client = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-client-consensus-common = { path = "../common" }

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -7,18 +7,18 @@ edition = "2018"
 
 [dependencies]
 # Substrate deps
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot deps
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-node-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-client = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-node-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-client = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 # other deps
 codec = { package = "parity-scale-codec", version = "2.3.0", features = [ "derive" ] }
@@ -36,14 +36,14 @@ cumulus-test-service = { path = "../../test/service" }
 cumulus-primitives-core = { path = "../../primitives/core" }
 
 # Polkadot deps
-polkadot-test-client = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-test-client = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 # substrate deps
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-keyring = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+substrate-test-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-service = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }

--- a/client/pov-recovery/Cargo.toml
+++ b/client/pov-recovery/Cargo.toml
@@ -7,18 +7,18 @@ edition = "2018"
 
 [dependencies]
 # Substrate deps
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-maybe-compressed-blob = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-maybe-compressed-blob = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot deps
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-node-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-overseer = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-node-subsystem = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-node-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-overseer = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-node-subsystem = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus deps
 cumulus-primitives-core = { path = "../../primitives/core" }
@@ -37,7 +37,7 @@ tokio = { version = "1.10", features = ["macros"] }
 cumulus-test-service = { path = "../../test/service" }
 
 # substrate deps
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+substrate-test-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-service = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -12,23 +12,23 @@ cumulus-client-pov-recovery = { path = "../pov-recovery" }
 cumulus-primitives-core = { path = "../../primitives/core" }
 
 # Substrate dependencies
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-consensus-babe = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sc-chain-spec = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-service = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-telemetry = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-consensus-babe = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot dependencies
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-overseer = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-overseer = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Other deps
 tracing = "0.1.22"

--- a/pallets/asset-tx-payment/Cargo.toml
+++ b/pallets/asset-tx-payment/Cargo.toml
@@ -14,13 +14,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Substrate dependencies
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
 
 # Other dependencies
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
@@ -31,10 +31,10 @@ serde = { version = "1.0.101", optional = true }
 smallvec = "1.4.1"
 serde_json = "1.0.41"
 
-pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-storage = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+pallet-assets = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-authorship = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-storage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = ["std"]

--- a/pallets/aura-ext/Cargo.toml
+++ b/pallets/aura-ext/Cargo.toml
@@ -7,14 +7,14 @@ description = "AURA consensus extension pallet for parachains"
 
 [dependencies]
 # Substrate dependencies
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-executive = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-aura = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus-aura = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-application-crypto = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Other Dependencies
 codec = { package = "parity-scale-codec", version = "2.3.0", default-features = false, features = ["derive"]}

--- a/pallets/collator-selection/Cargo.toml
+++ b/pallets/collator-selection/Cargo.toml
@@ -19,25 +19,25 @@ rand = { version = "0.7.2", default-features = false }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.119", default-features = false }
 
-sp-std = { default-features = false, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-sp-runtime = { default-features = false, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-sp-staking = { default-features = false, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-frame-support = { default-features = false, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-frame-system = { default-features = false, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-pallet-authorship = { default-features = false, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-pallet-session = { default-features = false, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
+sp-std = { default-features = false, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { default-features = false, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-staking = { default-features = false, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { default-features = false, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { default-features = false, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-authorship = { default-features = false, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-session = { default-features = false, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
-frame-benchmarking = { default-features = false, optional = true, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
+frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [dev-dependencies]
-sp-core = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-sp-io = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-sp-tracing = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-sp-runtime = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-pallet-timestamp = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-sp-consensus-aura = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-pallet-balances = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-pallet-aura = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus-aura = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-aura = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = ['std']

--- a/pallets/dmp-queue/Cargo.toml
+++ b/pallets/dmp-queue/Cargo.toml
@@ -11,22 +11,22 @@ scale-info = { version = "1.0.0", default-features = false, features = ["derive"
 log = { version = "0.4.14", default-features = false }
 
 # Substrate Dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot Dependencies
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm-executor = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus Dependencies
 cumulus-primitives-core = { path = "../../primitives/core", default-features = false }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-version = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = [ "std" ]

--- a/pallets/parachain-system/Cargo.toml
+++ b/pallets/parachain-system/Cargo.toml
@@ -7,9 +7,9 @@ description = "Base pallet for cumulus-based parachains"
 
 [dependencies]
 # Cumulus dependencies
-cumulus-primitives-core = { path = "../../primitives/core", default-features = false }
-cumulus-primitives-parachain-inherent = { path = "../../primitives/parachain-inherent", default-features = false }
-cumulus-pallet-parachain-system-proc-macro = { path = "proc-macro", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", default-features = false }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", default-features = false }
 
 # Polkadot dependencies
 polkadot-parachain = { git = "https://github.com/purestake/polkadot", default-features = false, features = [ "wasm-api" ], branch = "moonbeam-polkadot-v0.9.12" }

--- a/pallets/parachain-system/Cargo.toml
+++ b/pallets/parachain-system/Cargo.toml
@@ -12,22 +12,22 @@ cumulus-primitives-parachain-inherent = { path = "../../primitives/parachain-inh
 cumulus-pallet-parachain-system-proc-macro = { path = "proc-macro", default-features = false }
 
 # Polkadot dependencies
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, features = [ "wasm-api" ], branch = "release-v0.9.12" }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", default-features = false, features = [ "wasm-api" ], branch = "moonbeam-polkadot-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Substrate dependencies
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-trie = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-externalities = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-version = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-state-machine = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-trie = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-externalities = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Other Dependencies
 codec = { package = "parity-scale-codec", version = "2.3.0", default-features = false, features = ["derive"]}
@@ -42,10 +42,10 @@ hex-literal = "0.2.1"
 lazy_static = "1.4"
 
 # Substrate dependencies
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sp-version = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-keyring = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-test-client = { path = "../../test/client" }

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -741,7 +741,7 @@ impl<T: Config> Pallet<T> {
 			weight_used += T::DmpMessageHandler::handle_dmp_messages(message_iter, max_weight);
 			<LastDmqMqcHead<T>>::put(&dmq_head);
 
-			Self::deposit_event(Event::DownwardMessagesProcessed(weight_used, dmq_head.0));
+			Self::deposit_event(Event::DownwardMessagesProcessed(weight_used, dmq_head.head()));
 		}
 
 		// After hashing each message in the message queue chain submitted by the collator, we
@@ -749,7 +749,7 @@ impl<T: Config> Pallet<T> {
 		//
 		// A mismatch means that at least some of the submitted messages were altered, omitted or
 		// added improperly.
-		assert_eq!(dmq_head.0, expected_dmq_mqc_head);
+		assert_eq!(dmq_head.head(), expected_dmq_mqc_head);
 
 		ProcessedDownwardMessages::<T>::put(dm_count);
 

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -303,6 +303,9 @@ pub mod pallet {
 				horizontal_messages,
 			} = data;
 
+			log::info!(target: "mock-xcm", "🤞⛓️📨 In parachain inherent");
+			log::info!(target: "mock-xcm", "🤞⛓️📨 downward messages are: {:?}", downward_messages);
+
 			Self::validate_validation_data(&vfp);
 
 			let relay_state_proof = RelayChainStateProof::new(

--- a/pallets/session-benchmarking/Cargo.toml
+++ b/pallets/session-benchmarking/Cargo.toml
@@ -13,12 +13,12 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-std = { default-features = false, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-sp-runtime = { default-features = false, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-frame-support = { default-features = false, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-frame-system = { default-features = false, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-frame-benchmarking = { default-features = false, optional = true, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-pallet-session = { default-features = false, git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
+sp-std = { default-features = false, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { default-features = false, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { default-features = false, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { default-features = false, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-session = { default-features = false, git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = ["std"]

--- a/pallets/xcm/Cargo.toml
+++ b/pallets/xcm/Cargo.toml
@@ -9,13 +9,13 @@ codec = { package = "parity-scale-codec", version = "2.3.0", default-features = 
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 cumulus-primitives-core = { path = "../../primitives/core", default-features = false }
 

--- a/pallets/xcmp-queue/Cargo.toml
+++ b/pallets/xcmp-queue/Cargo.toml
@@ -12,24 +12,24 @@ scale-info = { version = "1.0.0", default-features = false, features = ["derive"
 log = { version = "0.4.14", default-features = false }
 
 # Substrate Dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot Dependencies
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm-executor = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus Dependencies
 cumulus-primitives-core = { path = "../../primitives/core", default-features = false }
 
 [dev-dependencies]
-sp-core = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-sp-io = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 cumulus-pallet-parachain-system = { path = "../parachain-system" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-pallet-balances = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
+xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = [ "std" ]

--- a/parachain-template/node/Cargo.toml
+++ b/parachain-template/node/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+substrate-build-script-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [[bin]]
 name = "parachain-collator"
@@ -37,45 +37,45 @@ jsonrpc-core = "18.0.0"
 parachain-template-runtime = { path = "../runtime" }
 
 # Substrate Dependencies
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+frame-benchmarking-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+pallet-transaction-payment-rpc = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+substrate-frame-rpc-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+substrate-prometheus-endpoint = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 ## Substrate Client Dependencies
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-service = { git = "https://github.com/paritytech/substrate", features = ["wasmtime"] , branch = "polkadot-v0.9.12" }
-sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sc-basic-authorship = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-chain-spec = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-executor = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-network = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-rpc = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-rpc-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-service = { git = "https://github.com/purestake/substrate", features = ["wasmtime"] , branch = "moonbeam-polkadot-v0.9.12" }
+sc-telemetry = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-transaction-pool-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 ## Substrate Primitive Dependencies
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus-aura = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-offchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-session = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-client-cli = { path = "../../client/cli" }
@@ -88,8 +88,8 @@ cumulus-primitives-core = { path = "../../primitives/core" }
 cumulus-primitives-parachain-inherent = { path = "../../primitives/parachain-inherent" }
 
 # Polkadot dependencies
-polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-cli = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-test-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }

--- a/parachain-template/pallets/template/Cargo.toml
+++ b/parachain-template/pallets/template/Cargo.toml
@@ -15,15 +15,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"], default-features = false }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true , branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", default-features = false, optional = true , branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
 
 [dev-dependencies]
 serde = { version = "1.0.119" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = ["std"]

--- a/parachain-template/runtime/Cargo.toml
+++ b/parachain-template/runtime/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"]}
@@ -26,37 +26,37 @@ pallet-template = { path = "../pallets/template", default-features = false }
 
 # Substrate Dependencies
 ## Substrate Primitive Dependencies
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus-aura = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-offchain = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-session = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-version = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
 
 ## Substrate FRAME Dependencies
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true , branch = "polkadot-v0.9.12" }
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true , branch = "polkadot-v0.9.12" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", default-features = false, optional = true , branch = "moonbeam-polkadot-v0.9.12" }
+frame-executive = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+frame-system-benchmarking = { git = "https://github.com/purestake/substrate", default-features = false, optional = true , branch = "moonbeam-polkadot-v0.9.12" }
+frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
 
 ## Substrate Pallet Dependencies
-pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.12" }
+pallet-aura = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-authorship = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-session = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-sudo = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-pallet-aura-ext = { path = "../../pallets/aura-ext", default-features = false }
@@ -71,12 +71,12 @@ pallet-collator-selection = { path = "../../pallets/collator-selection", default
 parachain-info = { path = "../../polkadot-parachains/pallets/parachain-info", default-features = false }
 
 # Polkadot Dependencies
-pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.12" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.12" }
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.12" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.12" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false , branch = "release-v0.9.12" }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-runtime-common = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+xcm-builder = { git = "https://github.com/purestake/polkadot", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+xcm-executor = { git = "https://github.com/purestake/polkadot", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = [

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -27,41 +27,41 @@ westmint-runtime = { path = "westmint" }
 parachains-common = { path = "parachains-common" }
 
 # Substrate dependencies
-frame-benchmarking = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-frame-benchmarking-cli = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+frame-benchmarking-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-session = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-executor = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-service = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-telemetry = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-network = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-basic-authorship = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-chain-spec = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-rpc = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-offchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus-aura = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+substrate-prometheus-endpoint = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # RPC related dependencies
 jsonrpc-core = "18.0.0"
-sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sc-transaction-pool-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment-rpc = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-client-cli = { path = "../client/cli" }
@@ -74,13 +74,13 @@ cumulus-primitives-core = { path = "../primitives/core" }
 cumulus-primitives-parachain-inherent = { path = "../primitives/parachain-inherent" }
 
 # Polkadot dependencies
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-cli = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+substrate-build-script-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [dev-dependencies]
 assert_cmd = "0.12"

--- a/polkadot-parachains/pallets/parachain-info/Cargo.toml
+++ b/polkadot-parachains/pallets/parachain-info/Cargo.toml
@@ -9,8 +9,8 @@ codec = { package = "parity-scale-codec", version = "2.3.0", default-features = 
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 cumulus-primitives-core = { path = "../../../primitives/core", default-features = false }
 

--- a/polkadot-parachains/pallets/ping/Cargo.toml
+++ b/polkadot-parachains/pallets/ping/Cargo.toml
@@ -9,12 +9,12 @@ codec = { package = "parity-scale-codec", version = "2.3.0", default-features = 
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 cumulus-primitives-core = { path = "../../../primitives/core", default-features = false }
 cumulus-pallet-xcm = { path = "../../../pallets/xcm", default-features = false }

--- a/polkadot-parachains/parachains-common/Cargo.toml
+++ b/polkadot-parachains/parachains-common/Cargo.toml
@@ -14,34 +14,34 @@ codec = { package = 'parity-scale-codec', version = '2.3.0', features = ['derive
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 
 # Substrate dependencies
-sp-consensus-aura = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
-sp-std = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
-sp-io = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
-frame-executive = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
-frame-support = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
-frame-system = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
-pallet-assets = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
-pallet-authorship = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
-pallet-balances = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
-sp-runtime = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
-sp-core = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
+sp-consensus-aura = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+frame-executive = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-assets = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-authorship = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot dependencies
-polkadot-runtime-common = { git = 'https://github.com/paritytech/polkadot', default-features = false , branch = "release-v0.9.12" }
-polkadot-primitives = { git = 'https://github.com/paritytech/polkadot', default-features = false , branch = "release-v0.9.12" }
-xcm = { git = 'https://github.com/paritytech/polkadot', default-features = false , branch = "release-v0.9.12" }
-xcm-executor = { git = 'https://github.com/paritytech/polkadot', default-features = false , branch = "release-v0.9.12" }
+polkadot-runtime-common = { git = "https://github.com/purestake/polkadot", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+xcm-executor = { git = "https://github.com/purestake/polkadot", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
 
 # Local dependencies
 pallet-asset-tx-payment = { path = '../../pallets/asset-tx-payment', default-features = false }
 pallet-collator-selection = { path = '../../pallets/collator-selection', default-features = false }
 
 [dev-dependencies]
-sp-io = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
-pallet-authorship = { git = 'https://github.com/paritytech/substrate', default-features = false , branch = "polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
+pallet-authorship = { git = "https://github.com/purestake/substrate", default-features = false , branch = "moonbeam-polkadot-v0.9.12" }
 
 [build-dependencies]
-substrate-wasm-builder = { git = 'https://github.com/paritytech/substrate', branch = "polkadot-v0.9.12" }
+substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = ["std"]

--- a/polkadot-parachains/rococo/Cargo.toml
+++ b/polkadot-parachains/rococo/Cargo.toml
@@ -13,31 +13,31 @@ scale-info = { version = "1.0.0", default-features = false, features = ["derive"
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 # Substrate dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-version = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-session = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-offchain = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus-aura = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-assets = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-executive = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-assets = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-sudo = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-aura = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 parachains-common = { path = "../parachains-common", default-features = false }
 
@@ -53,14 +53,14 @@ cumulus-pallet-xcm = { path = "../../pallets/xcm", default-features = false }
 cumulus-ping = { path = "../pallets/ping", default-features = false }
 
 # Polkadot dependencies
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm-builder = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm-executor = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = [ "std" ]

--- a/polkadot-parachains/shell/Cargo.toml
+++ b/polkadot-parachains/shell/Cargo.toml
@@ -12,21 +12,21 @@ scale-info = { version = "1.0.0", default-features = false, features = ["derive"
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 # Substrate dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-version = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-session = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-offchain = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-executive = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-pallet-parachain-system = { path = "../../pallets/parachain-system", default-features = false }
@@ -34,12 +34,12 @@ cumulus-primitives-core = { path = "../../primitives/core", default-features = f
 cumulus-primitives-utility = { path = "../../primitives/utility", default-features = false }
 cumulus-pallet-dmp-queue = { path = "../../pallets/dmp-queue", default-features = false }
 cumulus-pallet-xcm = { path = "../../pallets/xcm", default-features = false }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm-builder = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm-executor = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = [ "std" ]

--- a/polkadot-parachains/statemine/Cargo.toml
+++ b/polkadot-parachains/statemine/Cargo.toml
@@ -15,41 +15,41 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 smallvec = "1.6.1"
 
 # Substrate dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-version = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-session = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-offchain = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus-aura = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", optional = true, default-features = false, branch = "polkadot-v0.9.12" }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", optional = true, default-features = false, branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-assets = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-uniques = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", optional = true, default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system-benchmarking = { git = "https://github.com/purestake/substrate", optional = true, default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-executive = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-assets = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-aura = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-authorship = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-multisig = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-proxy = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-session = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-sudo = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-uniques = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-utility = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
-node-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+node-primitives = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-pallet-aura-ext = { path = "../../pallets/aura-ext", default-features = false }
@@ -67,18 +67,18 @@ pallet-collator-selection = { path = "../../pallets/collator-selection", default
 parachains-common = { path = "../parachains-common", default-features = false }
 
 # Polkadot dependencies
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-runtime-common = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm-builder = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm-executor = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 [dev-dependencies]
 hex-literal = "0.3.1"
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = [ "std" ]

--- a/polkadot-parachains/statemint/Cargo.toml
+++ b/polkadot-parachains/statemint/Cargo.toml
@@ -15,41 +15,41 @@ scale-info = { version = "1.0.0", default-features = false, features = ["derive"
 smallvec = "1.6.1"
 
 # Substrate dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-version = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-session = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-offchain = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus-aura = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", optional = true, default-features = false, branch = "polkadot-v0.9.12" }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", optional = true, default-features = false, branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-assets = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-uniques = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", optional = true, default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system-benchmarking = { git = "https://github.com/purestake/substrate", optional = true, default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-executive = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-assets = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-aura = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-authorship = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-multisig = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-proxy = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-session = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-sudo = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-uniques = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-utility = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
-node-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+node-primitives = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-pallet-aura-ext = { path = "../../pallets/aura-ext", default-features = false }
@@ -67,18 +67,18 @@ pallet-collator-selection = { path = "../../pallets/collator-selection", default
 parachains-common = { path = "../parachains-common", default-features = false }
 
 # Polkadot dependencies
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-runtime-common = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm-builder = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm-executor = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 [dev-dependencies]
 hex-literal = "0.3.1"
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = [ "std" ]

--- a/polkadot-parachains/westmint/Cargo.toml
+++ b/polkadot-parachains/westmint/Cargo.toml
@@ -15,41 +15,41 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 smallvec = "1.6.1"
 
 # Substrate dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-version = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-session = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-offchain = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus-aura = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", optional = true, default-features = false, branch = "polkadot-v0.9.12" }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", optional = true, default-features = false, branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-assets = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-multisig = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-uniques = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", optional = true, default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system-benchmarking = { git = "https://github.com/purestake/substrate", optional = true, default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-executive = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-assets = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-aura = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-authorship = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-multisig = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-proxy = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-session = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-sudo = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-uniques = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-utility = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
-node-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+node-primitives = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-pallet-aura-ext = { path = "../../pallets/aura-ext", default-features = false }
@@ -67,18 +67,18 @@ pallet-collator-selection = { path = "../../pallets/collator-selection", default
 parachains-common = { path = "../parachains-common", default-features = false }
 
 # Polkadot dependencies
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-runtime-common = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm-builder = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm-executor = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 [dev-dependencies]
 hex-literal = "0.3.1"
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = [ "std" ]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2018"
 
 [dependencies]
 # Substrate dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-trie = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-trie = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot dependencies
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-core-primitives = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Other dependencies
 impl-trait-for-tuples = "0.2.1"

--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -14,13 +14,14 @@ sp-std = { git = "https://github.com/purestake/substrate", default-features = fa
 sp-state-machine = { git = "https://github.com/purestake/substrate", optional = true , branch = "moonbeam-polkadot-v0.9.12" }
 sp-trie = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 sp-api = { git = "https://github.com/purestake/substrate", optional = true , branch = "moonbeam-polkadot-v0.9.12" }
+sp-storage = { git = "https://github.com/purestake/substrate", optional = true , branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot dependencies
 polkadot-client = { git = "https://github.com/purestake/polkadot", optional = true, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11", optional = true }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", optional = true }
 
 # Other dependencies
 async-trait = { version = "0.1.42", optional = true }

--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2018"
 
 [dependencies]
 # Substrate dependencies
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", optional = true , branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", optional = true , branch = "polkadot-v0.9.12" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate", optional = true , branch = "polkadot-v0.9.12" }
-sp-trie = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", optional = true , branch = "polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", optional = true , branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", optional = true , branch = "moonbeam-polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-state-machine = { git = "https://github.com/purestake/substrate", optional = true , branch = "moonbeam-polkadot-v0.9.12" }
+sp-trie = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", optional = true , branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot dependencies
-polkadot-client = { git = "https://github.com/paritytech/polkadot", optional = true, branch = "release-v0.9.12" }
+polkadot-client = { git = "https://github.com/purestake/polkadot", optional = true, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-primitives-core = { path = "../core", default-features = false }

--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -20,7 +20,7 @@ polkadot-client = { git = "https://github.com/purestake/polkadot", optional = tr
 
 # Cumulus dependencies
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11",, optional = true }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11", optional = true }
 
 # Other dependencies
 async-trait = { version = "0.1.42", optional = true }

--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -45,5 +45,6 @@ std = [
 	"sc-client-api",
 	"sp-api",
 	"polkadot-client",
-	"cumulus-test-relay-sproof-builder"
+	"cumulus-test-relay-sproof-builder",
+	"sp-storage",
 ]

--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -19,8 +19,8 @@ sp-api = { git = "https://github.com/purestake/substrate", optional = true , bra
 polkadot-client = { git = "https://github.com/purestake/polkadot", optional = true, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
-cumulus-primitives-core = { path = "../core", default-features = false }
-cumulus-test-relay-sproof-builder = { path = "../../test/relay-sproof-builder", optional = true }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11",, optional = true }
 
 # Other dependencies
 async-trait = { version = "0.1.42", optional = true }

--- a/primitives/parachain-inherent/src/lib.rs
+++ b/primitives/parachain-inherent/src/lib.rs
@@ -69,10 +69,6 @@ pub struct ParachainInherentData {
 	pub horizontal_messages: BTreeMap<ParaId, Vec<InboundHrmpMessage>>,
 }
 
-//TODO I copied this straight out of parachain system to avoid circular dependencies. It should
-// probably be moved here rather than copied.
-
-
 /// This struct provides ability to extend a message queue chain (MQC) and compute a new head.
 ///
 /// MQC is an instance of a [hash chain] applied to a message queue. Using a hash chain it's

--- a/primitives/parachain-inherent/src/lib.rs
+++ b/primitives/parachain-inherent/src/lib.rs
@@ -28,7 +28,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use cumulus_primitives_core::{
-	InboundDownwardMessage, InboundHrmpMessage, ParaId, PersistedValidationData, relay_chain::{BlakeTwo256, Hash as RelayHash, HashT as _},
+	relay_chain::{BlakeTwo256, Hash as RelayHash, HashT as _},
+	InboundDownwardMessage, InboundHrmpMessage, ParaId, PersistedValidationData,
 };
 
 use scale_info::TypeInfo;

--- a/primitives/parachain-inherent/src/lib.rs
+++ b/primitives/parachain-inherent/src/lib.rs
@@ -42,7 +42,7 @@ pub use client_side::*;
 #[cfg(feature = "std")]
 mod mock;
 #[cfg(feature = "std")]
-pub use mock::MockValidationDataInherentDataProvider;
+pub use mock::{MockValidationDataInherentDataProvider, MockXcmConfig};
 
 /// The identifier for the parachain inherent.
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"sysi1337";

--- a/primitives/parachain-inherent/src/lib.rs
+++ b/primitives/parachain-inherent/src/lib.rs
@@ -28,7 +28,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use cumulus_primitives_core::{
-	InboundDownwardMessage, InboundHrmpMessage, ParaId, PersistedValidationData,
+	InboundDownwardMessage, InboundHrmpMessage, ParaId, PersistedValidationData, relay_chain::{BlakeTwo256, Hash as RelayHash, HashT as _},
 };
 
 use scale_info::TypeInfo;
@@ -67,4 +67,45 @@ pub struct ParachainInherentData {
 	/// were sent. In combination with the rule of no more than one message in a channel per block,
 	/// this means `sent_at` is **strictly** greater than the previous one (if any).
 	pub horizontal_messages: BTreeMap<ParaId, Vec<InboundHrmpMessage>>,
+}
+
+//TODO I copied this straight out of parachain system to avoid circular dependencies. It should
+// probably be moved here rather than copied.
+
+
+/// This struct provides ability to extend a message queue chain (MQC) and compute a new head.
+///
+/// MQC is an instance of a [hash chain] applied to a message queue. Using a hash chain it's
+/// possible to represent a sequence of messages using only a single hash.
+///
+/// A head for an empty chain is agreed to be a zero hash.
+///
+/// [hash chain]: https://en.wikipedia.org/wiki/Hash_chain
+#[derive(Default, Clone, codec::Encode, codec::Decode, scale_info::TypeInfo)]
+pub struct MessageQueueChain(RelayHash);
+
+impl MessageQueueChain {
+	pub fn extend_hrmp(&mut self, horizontal_message: &InboundHrmpMessage) -> &mut Self {
+		let prev_head = self.0;
+		self.0 = BlakeTwo256::hash_of(&(
+			prev_head,
+			horizontal_message.sent_at,
+			BlakeTwo256::hash_of(&horizontal_message.data),
+		));
+		self
+	}
+
+	pub fn extend_downward(&mut self, downward_message: &InboundDownwardMessage) -> &mut Self {
+		let prev_head = self.0;
+		self.0 = BlakeTwo256::hash_of(&(
+			prev_head,
+			downward_message.sent_at,
+			BlakeTwo256::hash_of(&downward_message.msg),
+		));
+		self
+	}
+
+	pub fn head(&self) -> RelayHash {
+		self.0
+	}
 }

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -65,7 +65,7 @@ pub struct MockXcmConfig {
 impl MockXcmConfig {
 	/// Utility method for creating a MockXcmConfig by reading the dmq_mqc_head directly
 	/// from the storage of a previous block at common storage keys.
-	pub fn new_from_standard_storage<B: Block, BE: Backend<B>, C: StorageProvider<B, BE>>(
+	pub fn from_standard_storage<B: Block, BE: Backend<B>, C: StorageProvider<B, BE>>(
 		client: &C,
 		parent_block: B::Hash,
 		para_id: ParaId,

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -36,7 +36,10 @@ use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 /// To simulate a parachain that starts in relay block 1000 and gets a block in every other relay
 /// block, use 1000 and 2
 ///
-/// TODO Docs about the XCM injection
+/// Optionally, mock XCM messages can be injected into the runtime. When mocking XCM,
+/// in addition to the messages themselves, you must provide some information about
+/// your parachain's configuration in order to mock the MQC heads properly.
+/// See `MockXcmConfig` for more information
 pub struct MockValidationDataInherentDataProvider {
 	/// The current block number of the local block chain (the parachain)
 	pub current_para_block: u32,
@@ -46,6 +49,7 @@ pub struct MockValidationDataInherentDataProvider {
 	/// The number of relay blocks that elapses between each parablock. Probably set this to 1 or 2
 	/// to simulate optimistic or realistic relay chain behavior.
 	pub relay_blocks_per_para_block: u32,
+	//TODO Make this optional
 	/// XCM messages and associated configuration information.
 	pub xcm_config: MockXcmConfig,
 	/// Inbound downward XCM messages to be injected into the block.
@@ -54,7 +58,10 @@ pub struct MockValidationDataInherentDataProvider {
 	pub raw_horizontal_messages: Vec<(ParaId, Vec<u8>)>,
 }
 
-/// Parameters for how the Mock inherent data provider should inject XCM messages
+/// Parameters for how the Mock inherent data provider should inject XCM messages.
+/// In addition to the messages themselves, some information about the parachain's
+/// configuration is also required so that the MQC heads can be read out of the
+/// parachain's storage, and the corresponding relay data mocked.
 pub struct MockXcmConfig {
 	/// The parachain id of the parachain being mocked.
 	pub para_id: ParaId,

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -49,7 +49,6 @@ pub struct MockValidationDataInherentDataProvider {
 	/// The number of relay blocks that elapses between each parablock. Probably set this to 1 or 2
 	/// to simulate optimistic or realistic relay chain behavior.
 	pub relay_blocks_per_para_block: u32,
-	//TODO Make this optional
 	/// XCM messages and associated configuration information.
 	pub xcm_config: MockXcmConfig,
 	/// Inbound downward XCM messages to be injected into the block.
@@ -62,6 +61,7 @@ pub struct MockValidationDataInherentDataProvider {
 /// In addition to the messages themselves, some information about the parachain's
 /// configuration is also required so that the MQC heads can be read out of the
 /// parachain's storage, and the corresponding relay data mocked.
+#[derive(Default)]
 pub struct MockXcmConfig {
 	/// The parachain id of the parachain being mocked.
 	pub para_id: ParaId,

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -29,7 +29,7 @@ use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 /// relay_block_number = offset + relay_blocks_per_para_block * current_para_block
 /// To simulate a parachain that starts in relay block 1000 and gets a block in every other relay
 /// block, use 1000 and 2
-/// 
+///
 /// TODO Docs about the XCM injection
 pub struct MockValidationDataInherentDataProvider {
 	/// The current block number of the local block chain (the parachain)
@@ -54,8 +54,15 @@ impl InherentDataProvider for MockValidationDataInherentDataProvider {
 		inherent_data: &mut InherentData,
 	) -> Result<(), sp_inherents::Error> {
 		// Use the "sproof" (spoof proof) builder to build valid mock state root and proof.
-		let (relay_storage_root, proof) =
-			RelayStateSproofBuilder::default().into_state_root_and_proof();
+		let mut sproof_builder = RelayStateSproofBuilder::default();
+		println!("initial head: {:?}", sproof_builder.dmq_mqc_head);
+		// TODO This hash is copied from the log just to see if this approach works
+		// at all. I'll need to actually build the mcq_chain to do this properly.
+		sproof_builder.dmq_mqc_head = Some(sp_core::H256::from(hex_literal::hex!(
+			"3aa68593568d161595300df95c6164c11c6ce7c2ddd7ae816d8220e9273b555a"
+		)));
+		println!("modified head: {:?}", sproof_builder.dmq_mqc_head);
+		let (relay_storage_root, proof) = sproof_builder.into_state_root_and_proof();
 
 		// Calculate the mocked relay block based on the current para block
 		let relay_parent_number =

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -15,7 +15,7 @@
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{ParachainInherentData, INHERENT_IDENTIFIER};
-use cumulus_primitives_core::{InboundDownwardMessage, PersistedValidationData};
+use cumulus_primitives_core::{InboundDownwardMessage, PersistedValidationData, ParaId};
 use sp_inherents::{InherentData, InherentDataProvider};
 
 use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
@@ -32,6 +32,10 @@ use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 ///
 /// TODO Docs about the XCM injection
 pub struct MockValidationDataInherentDataProvider {
+	/// The parachain id of the parachain being mocked.
+	/// This field is only important if xcm is being used.
+	/// If you are not interested in injecting simulated XCM message, you ca nuse any value
+	pub para_id: ParaId,
 	/// The current block number of the local block chain (the parachain)
 	pub current_para_block: u32,
 	/// The relay block in which this parachain appeared to start. This will be the relay block
@@ -55,13 +59,14 @@ impl InherentDataProvider for MockValidationDataInherentDataProvider {
 	) -> Result<(), sp_inherents::Error> {
 		// Use the "sproof" (spoof proof) builder to build valid mock state root and proof.
 		let mut sproof_builder = RelayStateSproofBuilder::default();
+		// Set the sproof builder up to match the runtime
+		sproof_builder.para_id = self.para_id;
 		println!("initial head: {:?}", sproof_builder.dmq_mqc_head);
-		// TODO This hash is copied from the log just to see if this approach works
-		// at all. I'll need to actually build the mcq_chain to do this properly.
+		// TODO Eventually I'll need to actually build the mcq_chain to do this properly.
 		sproof_builder.dmq_mqc_head = Some(sp_core::H256::from(hex_literal::hex!(
-			"3aa68593568d161595300df95c6164c11c6ce7c2ddd7ae816d8220e9273b555a"
+			"6bc623c33c8aef0262bd9f9de1b18c3231f2ca48504d89a923953518d2bf2a44"
 		)));
-		println!("modified head: {:?}", sproof_builder.dmq_mqc_head);
+
 		let (relay_storage_root, proof) = sproof_builder.into_state_root_and_proof();
 
 		// Calculate the mocked relay block based on the current para block

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -15,7 +15,7 @@
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{ParachainInherentData, INHERENT_IDENTIFIER};
-use cumulus_primitives_core::PersistedValidationData;
+use cumulus_primitives_core::{InboundDownwardMessage, PersistedValidationData};
 use sp_inherents::{InherentData, InherentDataProvider};
 
 use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
@@ -29,6 +29,8 @@ use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 /// relay_block_number = offset + relay_blocks_per_para_block * current_para_block
 /// To simulate a parachain that starts in relay block 1000 and gets a block in every other relay
 /// block, use 1000 and 2
+/// 
+/// TODO Docs about the XCM injection
 pub struct MockValidationDataInherentDataProvider {
 	/// The current block number of the local block chain (the parachain)
 	pub current_para_block: u32,
@@ -38,6 +40,11 @@ pub struct MockValidationDataInherentDataProvider {
 	/// The number of relay blocks that elapses between each parablock. Probably set this to 1 or 2
 	/// to simulate optimistic or realistic relay chain behavior.
 	pub relay_blocks_per_para_block: u32,
+	/// Inbound downward XCM messages to be injected into the block.
+	pub downward_messages: Vec<InboundDownwardMessage>,
+	//TODO also support horizontal messages, but let's fous on downward for PoC phase.
+	// Inbound Horizontal messages sorted by channel
+	// pub horizontal_messages: BTreeMap<ParaId, Vec<InboundHrmpMessage>>
 }
 
 #[async_trait::async_trait]
@@ -61,7 +68,7 @@ impl InherentDataProvider for MockValidationDataInherentDataProvider {
 				relay_parent_number,
 				max_pov_size: Default::default(),
 			},
-			downward_messages: Default::default(),
+			downward_messages: self.downward_messages.clone(),
 			horizontal_messages: Default::default(),
 			relay_chain_state: proof,
 		};

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -64,20 +64,32 @@ pub struct MockXcmConfig {
 	pub starting_hrmp_mqc_heads: BTreeMap<ParaId, relay_chain::Hash>,
 }
 
+/// The same string name that is used for the parachain system pallet in the
+/// runtime. The parachain template, and many other popular chains use `ParachainSystem`,
+/// and a corresponding `Default` implementation of this type exists.
+pub struct ParachainSystemName(pub &'static [u8]);
+
+impl Default for ParachainSystemName {
+	fn default() -> Self {
+		Self(b"ParachainSystem")
+	}
+}
+
 impl MockXcmConfig {
-	/// Utility method for creating a MockXcmConfig by reading the mqc_heads directly
-	/// from the storage of a previous block at common storage keys.
-	pub fn from_standard_storage<B: Block, BE: Backend<B>, C: StorageProvider<B, BE>>(
+	/// Create a MockXcmConfig by reading the mqc_heads directly
+	/// from the storage of a previous block.
+	pub fn new<B: Block, BE: Backend<B>, C: StorageProvider<B, BE>>(
 		client: &C,
 		parent_block: B::Hash,
 		para_id: ParaId,
+		parachain_system_name: ParachainSystemName,
 	) -> Self {
 
 		let starting_dmq_mqc_head = client
 			.storage(
 				&BlockId::Hash(parent_block),
 				&sp_storage::StorageKey(
-					[twox_128(b"ParachainSystem"), twox_128(b"LastDmqMqcHead")].concat().to_vec(),
+					[twox_128(parachain_system_name.0), twox_128(b"LastDmqMqcHead")].concat().to_vec(),
 				),
 			)
 			.expect("We should be able to read storage from the parent block.")

--- a/primitives/timestamp/Cargo.toml
+++ b/primitives/timestamp/Cargo.toml
@@ -7,18 +7,18 @@ description = "Provides timestamp related functionality for parachains."
 
 [dependencies]
 # Substrate dependencies
-sp-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-timestamp = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-primitives-core = { path = "../core", default-features = false }
 
 [dev-dependencies]
 # Substrate dependencies
-sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sp-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-test-client = { path = "../../test/client" }

--- a/primitives/utility/Cargo.toml
+++ b/primitives/utility/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2018"
 
 [dependencies]
 # Substrate dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-trie = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-trie = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot dependencies
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-core-primitives = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+xcm = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 cumulus-primitives-core = { path = "../core", default-features = false }
 

--- a/test/client/Cargo.toml
+++ b/test/client/Cargo.toml
@@ -5,23 +5,23 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-executor-common = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-substrate-test-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sc-service = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-executor = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-executor-common = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+substrate-test-client = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-keyring = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus deps
 cumulus-test-runtime = { path = "../runtime" }
@@ -31,8 +31,8 @@ cumulus-primitives-core = { path = "../../primitives/core" }
 cumulus-primitives-parachain-inherent = { path = "../../primitives/parachain-inherent" }
 
 # Polkadot deps
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Other deps
 codec = { package = "parity-scale-codec", version = "2.3.0", default-features = false, features = [ "derive" ] }

--- a/test/relay-sproof-builder/Cargo.toml
+++ b/test/relay-sproof-builder/Cargo.toml
@@ -9,12 +9,12 @@ edition = '2018'
 codec = { package = "parity-scale-codec", version = "2.3.0", default-features = false, features = [ "derive" ] }
 
 # Substrate dependencies
-sp-state-machine = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+sp-state-machine = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot dependencies
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-primitives-core = { path = "../../primitives/core", default-features = false }

--- a/test/relay-validation-worker-provider/Cargo.toml
+++ b/test/relay-validation-worker-provider/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-polkadot-node-core-pvf = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-node-core-pvf = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }

--- a/test/runtime-upgrade/Cargo.toml
+++ b/test/runtime-upgrade/Cargo.toml
@@ -10,25 +10,25 @@ scale-info = { version = "1.0.0", default-features = false, features = ["derive"
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 # Substrate dependencies
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+frame-executive = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-sudo = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-offchain = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-session = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-version = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-pallet-parachain-system = { path = "../../pallets/parachain-system", default-features = false }
@@ -36,7 +36,7 @@ cumulus-primitives-core = { path = "../../primitives/core", default-features = f
 cumulus-primitives-timestamp = { path = "../../primitives/timestamp", default-features = false }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = [ "std", "upgrade" ]

--- a/test/runtime/Cargo.toml
+++ b/test/runtime/Cargo.toml
@@ -10,25 +10,25 @@ scale-info = { version = "1.0.0", default-features = false, features = ["derive"
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 # Substrate dependencies
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
+frame-executive = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-support = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-balances = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-sudo = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-api = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-inherents = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-io = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-offchain = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-session = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-std = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-version = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
 cumulus-pallet-parachain-system = { path = "../../pallets/parachain-system", default-features = false }
@@ -36,7 +36,7 @@ cumulus-primitives-core = { path = "../../primitives/core", default-features = f
 cumulus-primitives-timestamp = { path = "../../primitives/timestamp", default-features = false }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 [features]
 default = [ "std" ]

--- a/test/service/Cargo.toml
+++ b/test/service/Cargo.toml
@@ -12,32 +12,32 @@ async-trait = "0.1.42"
 tokio = { version = "1.10", features = ["macros"] }
 
 # Substrate
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12" }
-sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-substrate-test-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-basic-authorship = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-chain-spec = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-executor = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-network = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-rpc = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-service = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sc-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-arithmetic = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-keyring = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-runtime = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
+sp-state-machine = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-trie = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+substrate-test-client = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
-polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
+polkadot-test-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus
 cumulus-client-consensus-relay-chain = { path = "../../client/consensus/relay-chain" }
@@ -56,13 +56,13 @@ jsonrpc-core = "18.0.0"
 futures = "0.3.5"
 
 # Polkadot dependencies
-polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.12" }
+polkadot-test-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Substrate dependencies
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-maybe-compressed-blob = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-sp-version = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+sc-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+substrate-test-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-maybe-compressed-blob = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
+sp-version = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus
 cumulus-test-runtime-upgrade = { path = "../runtime-upgrade" }


### PR DESCRIPTION
This Hotfix represents us merging https://github.com/paritytech/cumulus/pull/772 into our hotfix branch before it is accepted upstream.

This change will probably be available in stock cumulus in the `polkadot-v0.9.14` or `polkadot-v0.9.15` release. Until then, we will keep it as a hotfix.

However, this hotfix can be replaced with a direct cherry-picking from `master` once this work is merged upstream.