### PR TITLE
Premerging Upstream Cumulus PR #772 (mock XCM)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,6 +1796,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
+ "sp-storage",
  "sp-trie",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,9 +1639,9 @@ dependencies = [
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
 dependencies = [
- "cumulus-pallet-parachain-system-proc-macro",
- "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-pallet-parachain-system-proc-macro 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
  "cumulus-test-client",
  "cumulus-test-relay-sproof-builder 0.1.0",
  "environmental",
@@ -1673,6 +1673,17 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
+dependencies = [
+ "proc-macro-crate 1.1.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cumulus-pallet-parachain-system-proc-macro"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12#ea2b71e0f6030abdb5dfc67bb53af111d336b6f2"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -1802,6 +1813,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-primitives-parachain-inherent"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12#ea2b71e0f6030abdb5dfc67bb53af111d336b6f2"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "parity-scale-codec",
+ "polkadot-client",
+ "sc-client-api",
+ "scale-info",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
+ "tracing",
+]
+
+[[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
 dependencies = [
@@ -1839,7 +1872,7 @@ name = "cumulus-test-client"
 version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-parachain-inherent 0.1.0",
  "cumulus-test-relay-sproof-builder 0.1.0",
  "cumulus-test-runtime",
  "cumulus-test-service",
@@ -1971,7 +2004,7 @@ dependencies = [
  "cumulus-client-network",
  "cumulus-client-service",
  "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-parachain-inherent 0.1.0",
  "cumulus-test-relay-validation-worker-provider",
  "cumulus-test-runtime",
  "cumulus-test-runtime-upgrade",
@@ -6039,7 +6072,7 @@ dependencies = [
  "cumulus-client-network",
  "cumulus-client-service",
  "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-parachain-inherent 0.1.0",
  "derive_more",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -6651,7 +6684,7 @@ dependencies = [
  "cumulus-client-network",
  "cumulus-client-service",
  "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-parachain-inherent 0.1.0",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "futures 0.3.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.11#e0ef78f83dd9d1167d6fc520598f53cdcac5a1e1"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12#ea2b71e0f6030abdb5dfc67bb53af111d336b6f2"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1784,8 +1784,8 @@ name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
  "parity-scale-codec",
  "polkadot-client",
  "sc-client-api",
@@ -1880,9 +1880,9 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.11#e0ef78f83dd9d1167d6fc520598f53cdcac5a1e1"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12#ea2b71e0f6030abdb5dfc67bb53af111d336b6f2"
 dependencies = [
- "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.11)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,9 +1639,9 @@ dependencies = [
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
 dependencies = [
- "cumulus-pallet-parachain-system-proc-macro 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
- "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
- "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "cumulus-pallet-parachain-system-proc-macro 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
  "cumulus-test-client",
  "cumulus-test-relay-sproof-builder 0.1.0",
  "environmental",
@@ -1683,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12#ea2b71e0f6030abdb5dfc67bb53af111d336b6f2"
+source = "git+https://github.com/paritytech/cumulus?branch=master#6b603201c534dec955e20b64e2dd20b16d9016fb"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12#ea2b71e0f6030abdb5dfc67bb53af111d336b6f2"
+source = "git+https://github.com/paritytech/cumulus?branch=master#6b603201c534dec955e20b64e2dd20b16d9016fb"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1795,8 +1795,8 @@ name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
- "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
  "parity-scale-codec",
  "polkadot-client",
  "sc-client-api",
@@ -1815,11 +1815,11 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12#ea2b71e0f6030abdb5dfc67bb53af111d336b6f2"
+source = "git+https://github.com/paritytech/cumulus?branch=master#6b603201c534dec955e20b64e2dd20b16d9016fb"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
- "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
  "parity-scale-codec",
  "polkadot-client",
  "sc-client-api",
@@ -1913,9 +1913,9 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12#ea2b71e0f6030abdb5dfc67bb53af111d336b6f2"
+source = "git+https://github.com/paritytech/cumulus?branch=master#6b603201c534dec955e20b64e2dd20b16d9016fb"
 dependencies = [
- "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.12)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
  "cumulus-client-network",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-test-client",
  "cumulus-test-runtime",
  "futures 0.3.17",
@@ -1444,7 +1444,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "futures 0.3.17",
  "parity-scale-codec",
  "polkadot-client",
@@ -1495,7 +1495,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "futures 0.3.17",
  "parking_lot 0.10.2",
  "polkadot-client",
@@ -1516,7 +1516,7 @@ dependencies = [
 name = "cumulus-client-network"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-test-service",
  "derive_more",
  "futures 0.3.17",
@@ -1547,7 +1547,7 @@ dependencies = [
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-test-service",
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -1577,7 +1577,7 @@ dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-pov-recovery",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "polkadot-overseer",
@@ -1620,7 +1620,7 @@ dependencies = [
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "frame-support",
  "frame-system",
  "log",
@@ -1640,10 +1640,10 @@ name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-test-client",
- "cumulus-test-relay-sproof-builder 0.1.0",
+ "cumulus-test-relay-sproof-builder",
  "environmental",
  "frame-support",
  "frame-system",
@@ -1696,7 +1696,7 @@ dependencies = [
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -1713,7 +1713,7 @@ name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "frame-support",
  "frame-system",
  "log",
@@ -1735,7 +1735,7 @@ name = "cumulus-ping"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-xcm",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -1763,29 +1763,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cumulus-primitives-core"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#6b603201c534dec955e20b64e2dd20b16d9016fb"
-dependencies = [
- "frame-support",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
- "polkadot-primitives",
- "sp-api",
- "sp-runtime",
- "sp-std",
- "sp-trie",
-]
-
-[[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
- "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
+ "cumulus-primitives-core",
+ "cumulus-test-relay-sproof-builder",
  "parity-scale-codec",
  "polkadot-client",
  "sc-client-api",
@@ -1805,9 +1788,9 @@ dependencies = [
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-test-client",
- "cumulus-test-relay-sproof-builder 0.1.0",
+ "cumulus-test-relay-sproof-builder",
  "futures 0.3.17",
  "parity-scale-codec",
  "sp-consensus",
@@ -1822,7 +1805,7 @@ dependencies = [
 name = "cumulus-primitives-utility"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "frame-support",
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -1838,9 +1821,9 @@ dependencies = [
 name = "cumulus-test-client"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
- "cumulus-test-relay-sproof-builder 0.1.0",
+ "cumulus-test-relay-sproof-builder",
  "cumulus-test-runtime",
  "cumulus-test-service",
  "frame-system",
@@ -1869,20 +1852,7 @@ dependencies = [
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core 0.1.0",
- "parity-scale-codec",
- "polkadot-primitives",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
-]
-
-[[package]]
-name = "cumulus-test-relay-sproof-builder"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#6b603201c534dec955e20b64e2dd20b16d9016fb"
-dependencies = [
- "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
+ "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-runtime",
@@ -1902,7 +1872,7 @@ name = "cumulus-test-runtime"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "frame-executive",
  "frame-support",
@@ -1970,7 +1940,7 @@ dependencies = [
  "cumulus-client-consensus-relay-chain",
  "cumulus-client-network",
  "cumulus-client-service",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-test-relay-validation-worker-provider",
  "cumulus-test-runtime",
@@ -6020,7 +5990,7 @@ dependencies = [
 name = "parachain-info"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -6038,7 +6008,7 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-client-service",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "derive_more",
  "frame-benchmarking",
@@ -6098,7 +6068,7 @@ dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",
@@ -6650,7 +6620,7 @@ dependencies = [
  "cumulus-client-consensus-relay-chain",
  "cumulus-client-network",
  "cumulus-client-service",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -8407,7 +8377,7 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-ping",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-executive",
@@ -9853,7 +9823,7 @@ dependencies = [
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcm",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-primitives-utility",
  "frame-executive",
  "frame-support",
@@ -10731,7 +10701,7 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-ping",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",
@@ -10797,7 +10767,7 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-ping",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",
@@ -12216,7 +12186,7 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-ping",
- "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,9 +1639,9 @@ dependencies = [
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
 dependencies = [
- "cumulus-pallet-parachain-system-proc-macro 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
- "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
- "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
+ "cumulus-pallet-parachain-system-proc-macro",
+ "cumulus-primitives-core 0.1.0",
+ "cumulus-primitives-parachain-inherent",
  "cumulus-test-client",
  "cumulus-test-relay-sproof-builder 0.1.0",
  "environmental",
@@ -1673,17 +1673,6 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-dependencies = [
- "proc-macro-crate 1.1.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "cumulus-pallet-parachain-system-proc-macro"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#6b603201c534dec955e20b64e2dd20b16d9016fb"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -1813,28 +1802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cumulus-primitives-parachain-inherent"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#6b603201c534dec955e20b64e2dd20b16d9016fb"
-dependencies = [
- "async-trait",
- "cumulus-primitives-core 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
- "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/paritytech/cumulus?branch=master)",
- "parity-scale-codec",
- "polkadot-client",
- "sc-client-api",
- "scale-info",
- "sp-api",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
- "sp-trie",
- "tracing",
-]
-
-[[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
 dependencies = [
@@ -1872,7 +1839,7 @@ name = "cumulus-test-client"
 version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent 0.1.0",
+ "cumulus-primitives-parachain-inherent",
  "cumulus-test-relay-sproof-builder 0.1.0",
  "cumulus-test-runtime",
  "cumulus-test-service",
@@ -2004,7 +1971,7 @@ dependencies = [
  "cumulus-client-network",
  "cumulus-client-service",
  "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent 0.1.0",
+ "cumulus-primitives-parachain-inherent",
  "cumulus-test-relay-validation-worker-provider",
  "cumulus-test-runtime",
  "cumulus-test-runtime-upgrade",
@@ -6072,7 +6039,7 @@ dependencies = [
  "cumulus-client-network",
  "cumulus-client-service",
  "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent 0.1.0",
+ "cumulus-primitives-parachain-inherent",
  "derive_more",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -6684,7 +6651,7 @@ dependencies = [
  "cumulus-client-network",
  "cumulus-client-service",
  "cumulus-primitives-core 0.1.0",
- "cumulus-primitives-parachain-inherent 0.1.0",
+ "cumulus-primitives-parachain-inherent",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "futures 0.3.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
  "cumulus-client-network",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-test-client",
  "cumulus-test-runtime",
  "futures 0.3.17",
@@ -1444,7 +1444,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "futures 0.3.17",
  "parity-scale-codec",
  "polkadot-client",
@@ -1495,7 +1495,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "futures 0.3.17",
  "parking_lot 0.10.2",
  "polkadot-client",
@@ -1516,7 +1516,7 @@ dependencies = [
 name = "cumulus-client-network"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-test-service",
  "derive_more",
  "futures 0.3.17",
@@ -1547,7 +1547,7 @@ dependencies = [
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-test-service",
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -1577,7 +1577,7 @@ dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-pov-recovery",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "polkadot-overseer",
@@ -1620,7 +1620,7 @@ dependencies = [
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "frame-support",
  "frame-system",
  "log",
@@ -1640,10 +1640,10 @@ name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-parachain-inherent",
  "cumulus-test-client",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-test-relay-sproof-builder 0.1.0",
  "environmental",
  "frame-support",
  "frame-system",
@@ -1696,7 +1696,7 @@ dependencies = [
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -1713,7 +1713,7 @@ name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "frame-support",
  "frame-system",
  "log",
@@ -1735,7 +1735,7 @@ name = "cumulus-ping"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-xcm",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -1749,6 +1749,23 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
+ "sp-trie",
+]
+
+[[package]]
+name = "cumulus-primitives-core"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.11#e0ef78f83dd9d1167d6fc520598f53cdcac5a1e1"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1787,9 +1804,9 @@ dependencies = [
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-test-client",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-test-relay-sproof-builder 0.1.0",
  "futures 0.3.17",
  "parity-scale-codec",
  "sp-consensus",
@@ -1804,7 +1821,7 @@ dependencies = [
 name = "cumulus-primitives-utility"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "frame-support",
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -1820,9 +1837,9 @@ dependencies = [
 name = "cumulus-test-client"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-parachain-inherent",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-test-relay-sproof-builder 0.1.0",
  "cumulus-test-runtime",
  "cumulus-test-service",
  "frame-system",
@@ -1851,7 +1868,20 @@ dependencies = [
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+]
+
+[[package]]
+name = "cumulus-test-relay-sproof-builder"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.11#e0ef78f83dd9d1167d6fc520598f53cdcac5a1e1"
+dependencies = [
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.11)",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-runtime",
@@ -1871,7 +1901,7 @@ name = "cumulus-test-runtime"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "frame-executive",
  "frame-support",
@@ -1939,7 +1969,7 @@ dependencies = [
  "cumulus-client-consensus-relay-chain",
  "cumulus-client-network",
  "cumulus-client-service",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-parachain-inherent",
  "cumulus-test-relay-validation-worker-provider",
  "cumulus-test-runtime",
@@ -5989,7 +6019,7 @@ dependencies = [
 name = "parachain-info"
 version = "0.1.0"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -6007,7 +6037,7 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-client-service",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-parachain-inherent",
  "derive_more",
  "frame-benchmarking",
@@ -6067,7 +6097,7 @@ dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",
@@ -6619,7 +6649,7 @@ dependencies = [
  "cumulus-client-consensus-relay-chain",
  "cumulus-client-network",
  "cumulus-client-service",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-parachain-inherent",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -8376,7 +8406,7 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-ping",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-executive",
@@ -9822,7 +9852,7 @@ dependencies = [
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcm",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-utility",
  "frame-executive",
  "frame-support",
@@ -10700,7 +10730,7 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-ping",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",
@@ -10766,7 +10796,7 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-ping",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",
@@ -12185,7 +12215,7 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-ping",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "frame-benchmarking",

--- a/pallets/parachain-system/Cargo.toml
+++ b/pallets/parachain-system/Cargo.toml
@@ -7,9 +7,9 @@ description = "Base pallet for cumulus-based parachains"
 
 [dependencies]
 # Cumulus dependencies
-cumulus-primitives-core = { path = "../../primitives/core", default-features = false }
-cumulus-primitives-parachain-inherent = { path = "../../primitives/parachain-inherent", default-features = false }
-cumulus-pallet-parachain-system-proc-macro = { path = "proc-macro", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", default-features = false }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", default-features = false }
 
 # Polkadot dependencies
 polkadot-parachain = { git = "https://github.com/purestake/polkadot", default-features = false, features = [ "wasm-api" ], branch = "moonbeam-polkadot-v0.9.12" }

--- a/pallets/parachain-system/Cargo.toml
+++ b/pallets/parachain-system/Cargo.toml
@@ -7,9 +7,9 @@ description = "Base pallet for cumulus-based parachains"
 
 [dependencies]
 # Cumulus dependencies
-cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "master", default-features = false }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/cumulus", branch = "master", default-features = false }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/paritytech/cumulus", branch = "master", default-features = false }
+cumulus-primitives-core = { path = "../../primitives/core", default-features = false }
+cumulus-primitives-parachain-inherent = { path = "../../primitives/parachain-inherent", default-features = false }
+cumulus-pallet-parachain-system-proc-macro = { path = "proc-macro", default-features = false }
 
 # Polkadot dependencies
 polkadot-parachain = { git = "https://github.com/purestake/polkadot", default-features = false, features = [ "wasm-api" ], branch = "moonbeam-polkadot-v0.9.12" }

--- a/pallets/parachain-system/Cargo.toml
+++ b/pallets/parachain-system/Cargo.toml
@@ -7,9 +7,9 @@ description = "Base pallet for cumulus-based parachains"
 
 [dependencies]
 # Cumulus dependencies
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", default-features = false }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", default-features = false }
-cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "master", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/cumulus", branch = "master", default-features = false }
+cumulus-pallet-parachain-system-proc-macro = { git = "https://github.com/paritytech/cumulus", branch = "master", default-features = false }
 
 # Polkadot dependencies
 polkadot-parachain = { git = "https://github.com/purestake/polkadot", default-features = false, features = [ "wasm-api" ], branch = "moonbeam-polkadot-v0.9.12" }

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -741,7 +741,7 @@ impl<T: Config> Pallet<T> {
 			weight_used += T::DmpMessageHandler::handle_dmp_messages(message_iter, max_weight);
 			<LastDmqMqcHead<T>>::put(&dmq_head);
 
-			Self::deposit_event(Event::DownwardMessagesProcessed(weight_used, dmq_head.0));
+			Self::deposit_event(Event::DownwardMessagesProcessed(weight_used, dmq_head.head()));
 		}
 
 		// After hashing each message in the message queue chain submitted by the collator, we
@@ -749,7 +749,7 @@ impl<T: Config> Pallet<T> {
 		//
 		// A mismatch means that at least some of the submitted messages were altered, omitted or
 		// added improperly.
-		assert_eq!(dmq_head.0, expected_dmq_mqc_head);
+		assert_eq!(dmq_head.head(), expected_dmq_mqc_head);
 
 		ProcessedDownwardMessages::<T>::put(dm_count);
 

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -303,9 +303,6 @@ pub mod pallet {
 				horizontal_messages,
 			} = data;
 
-			log::info!(target: "mock-xcm", "🤞⛓️📨 In parachain inherent");
-			log::info!(target: "mock-xcm", "🤞⛓️📨 downward messages are: {:?}", downward_messages);
-
 			Self::validate_validation_data(&vfp);
 
 			let relay_state_proof = RelayChainStateProof::new(

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -303,6 +303,9 @@ pub mod pallet {
 				horizontal_messages,
 			} = data;
 
+			log::info!(target: "mock-xcm", "🤞⛓️📨 In parachain inherent");
+			log::info!(target: "mock-xcm", "🤞⛓️📨 downward messages are: {:?}", downward_messages);
+
 			Self::validate_validation_data(&vfp);
 
 			let relay_state_proof = RelayChainStateProof::new(

--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -14,13 +14,14 @@ sp-std = { git = "https://github.com/purestake/substrate", default-features = fa
 sp-state-machine = { git = "https://github.com/purestake/substrate", optional = true , branch = "moonbeam-polkadot-v0.9.12" }
 sp-trie = { git = "https://github.com/purestake/substrate", default-features = false, branch = "moonbeam-polkadot-v0.9.12" }
 sp-api = { git = "https://github.com/purestake/substrate", optional = true , branch = "moonbeam-polkadot-v0.9.12" }
+sp-storage = { git = "https://github.com/purestake/substrate", optional = true , branch = "moonbeam-polkadot-v0.9.12" }
 
 # Polkadot dependencies
 polkadot-client = { git = "https://github.com/purestake/polkadot", optional = true, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11", optional = true }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", optional = true }
 
 # Other dependencies
 async-trait = { version = "0.1.42", optional = true }

--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -20,7 +20,7 @@ polkadot-client = { git = "https://github.com/purestake/polkadot", optional = tr
 
 # Cumulus dependencies
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11",, optional = true }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11", optional = true }
 
 # Other dependencies
 async-trait = { version = "0.1.42", optional = true }

--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -45,5 +45,6 @@ std = [
 	"sc-client-api",
 	"sp-api",
 	"polkadot-client",
-	"cumulus-test-relay-sproof-builder"
+	"cumulus-test-relay-sproof-builder",
+	"sp-storage",
 ]

--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -19,8 +19,8 @@ sp-api = { git = "https://github.com/purestake/substrate", optional = true , bra
 polkadot-client = { git = "https://github.com/purestake/polkadot", optional = true, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
-cumulus-primitives-core = { path = "../core", default-features = false }
-cumulus-test-relay-sproof-builder = { path = "../../test/relay-sproof-builder", optional = true }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.11",, optional = true }
 
 # Other dependencies
 async-trait = { version = "0.1.42", optional = true }

--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -20,8 +20,8 @@ sp-storage = { git = "https://github.com/purestake/substrate", optional = true ,
 polkadot-client = { git = "https://github.com/purestake/polkadot", optional = true, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
-cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "master", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/paritytech/cumulus", branch = "master", optional = true }
+cumulus-primitives-core = { path = "../core", default-features = false }
+cumulus-test-relay-sproof-builder = { path = "../../test/relay-sproof-builder", optional = true }
 
 # Other dependencies
 async-trait = { version = "0.1.42", optional = true }

--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -20,8 +20,8 @@ sp-storage = { git = "https://github.com/purestake/substrate", optional = true ,
 polkadot-client = { git = "https://github.com/purestake/polkadot", optional = true, branch = "moonbeam-polkadot-v0.9.12" }
 
 # Cumulus dependencies
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.12", optional = true }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "master", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/paritytech/cumulus", branch = "master", optional = true }
 
 # Other dependencies
 async-trait = { version = "0.1.42", optional = true }

--- a/primitives/parachain-inherent/src/lib.rs
+++ b/primitives/parachain-inherent/src/lib.rs
@@ -69,10 +69,6 @@ pub struct ParachainInherentData {
 	pub horizontal_messages: BTreeMap<ParaId, Vec<InboundHrmpMessage>>,
 }
 
-//TODO I copied this straight out of parachain system to avoid circular dependencies. It should
-// probably be moved here rather than copied.
-
-
 /// This struct provides ability to extend a message queue chain (MQC) and compute a new head.
 ///
 /// MQC is an instance of a [hash chain] applied to a message queue. Using a hash chain it's

--- a/primitives/parachain-inherent/src/lib.rs
+++ b/primitives/parachain-inherent/src/lib.rs
@@ -28,7 +28,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use cumulus_primitives_core::{
-	InboundDownwardMessage, InboundHrmpMessage, ParaId, PersistedValidationData, relay_chain::{BlakeTwo256, Hash as RelayHash, HashT as _},
+	relay_chain::{BlakeTwo256, Hash as RelayHash, HashT as _},
+	InboundDownwardMessage, InboundHrmpMessage, ParaId, PersistedValidationData,
 };
 
 use scale_info::TypeInfo;

--- a/primitives/parachain-inherent/src/lib.rs
+++ b/primitives/parachain-inherent/src/lib.rs
@@ -42,7 +42,7 @@ pub use client_side::*;
 #[cfg(feature = "std")]
 mod mock;
 #[cfg(feature = "std")]
-pub use mock::MockValidationDataInherentDataProvider;
+pub use mock::{MockValidationDataInherentDataProvider, MockXcmConfig};
 
 /// The identifier for the parachain inherent.
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"sysi1337";

--- a/primitives/parachain-inherent/src/lib.rs
+++ b/primitives/parachain-inherent/src/lib.rs
@@ -28,7 +28,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use cumulus_primitives_core::{
-	InboundDownwardMessage, InboundHrmpMessage, ParaId, PersistedValidationData,
+	InboundDownwardMessage, InboundHrmpMessage, ParaId, PersistedValidationData, relay_chain::{BlakeTwo256, Hash as RelayHash, HashT as _},
 };
 
 use scale_info::TypeInfo;
@@ -67,4 +67,45 @@ pub struct ParachainInherentData {
 	/// were sent. In combination with the rule of no more than one message in a channel per block,
 	/// this means `sent_at` is **strictly** greater than the previous one (if any).
 	pub horizontal_messages: BTreeMap<ParaId, Vec<InboundHrmpMessage>>,
+}
+
+//TODO I copied this straight out of parachain system to avoid circular dependencies. It should
+// probably be moved here rather than copied.
+
+
+/// This struct provides ability to extend a message queue chain (MQC) and compute a new head.
+///
+/// MQC is an instance of a [hash chain] applied to a message queue. Using a hash chain it's
+/// possible to represent a sequence of messages using only a single hash.
+///
+/// A head for an empty chain is agreed to be a zero hash.
+///
+/// [hash chain]: https://en.wikipedia.org/wiki/Hash_chain
+#[derive(Default, Clone, codec::Encode, codec::Decode, scale_info::TypeInfo)]
+pub struct MessageQueueChain(RelayHash);
+
+impl MessageQueueChain {
+	pub fn extend_hrmp(&mut self, horizontal_message: &InboundHrmpMessage) -> &mut Self {
+		let prev_head = self.0;
+		self.0 = BlakeTwo256::hash_of(&(
+			prev_head,
+			horizontal_message.sent_at,
+			BlakeTwo256::hash_of(&horizontal_message.data),
+		));
+		self
+	}
+
+	pub fn extend_downward(&mut self, downward_message: &InboundDownwardMessage) -> &mut Self {
+		let prev_head = self.0;
+		self.0 = BlakeTwo256::hash_of(&(
+			prev_head,
+			downward_message.sent_at,
+			BlakeTwo256::hash_of(&downward_message.msg),
+		));
+		self
+	}
+
+	pub fn head(&self) -> RelayHash {
+		self.0
+	}
 }

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -65,7 +65,7 @@ pub struct MockXcmConfig {
 impl MockXcmConfig {
 	/// Utility method for creating a MockXcmConfig by reading the dmq_mqc_head directly
 	/// from the storage of a previous block at common storage keys.
-	pub fn new_from_standard_storage<B: Block, BE: Backend<B>, C: StorageProvider<B, BE>>(
+	pub fn from_standard_storage<B: Block, BE: Backend<B>, C: StorageProvider<B, BE>>(
 		client: &C,
 		parent_block: B::Hash,
 		para_id: ParaId,

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -36,7 +36,10 @@ use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 /// To simulate a parachain that starts in relay block 1000 and gets a block in every other relay
 /// block, use 1000 and 2
 ///
-/// TODO Docs about the XCM injection
+/// Optionally, mock XCM messages can be injected into the runtime. When mocking XCM,
+/// in addition to the messages themselves, you must provide some information about
+/// your parachain's configuration in order to mock the MQC heads properly.
+/// See `MockXcmConfig` for more information
 pub struct MockValidationDataInherentDataProvider {
 	/// The current block number of the local block chain (the parachain)
 	pub current_para_block: u32,
@@ -46,6 +49,7 @@ pub struct MockValidationDataInherentDataProvider {
 	/// The number of relay blocks that elapses between each parablock. Probably set this to 1 or 2
 	/// to simulate optimistic or realistic relay chain behavior.
 	pub relay_blocks_per_para_block: u32,
+	//TODO Make this optional
 	/// XCM messages and associated configuration information.
 	pub xcm_config: MockXcmConfig,
 	/// Inbound downward XCM messages to be injected into the block.
@@ -54,7 +58,10 @@ pub struct MockValidationDataInherentDataProvider {
 	pub raw_horizontal_messages: Vec<(ParaId, Vec<u8>)>,
 }
 
-/// Parameters for how the Mock inherent data provider should inject XCM messages
+/// Parameters for how the Mock inherent data provider should inject XCM messages.
+/// In addition to the messages themselves, some information about the parachain's
+/// configuration is also required so that the MQC heads can be read out of the
+/// parachain's storage, and the corresponding relay data mocked.
 pub struct MockXcmConfig {
 	/// The parachain id of the parachain being mocked.
 	pub para_id: ParaId,

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -49,7 +49,6 @@ pub struct MockValidationDataInherentDataProvider {
 	/// The number of relay blocks that elapses between each parablock. Probably set this to 1 or 2
 	/// to simulate optimistic or realistic relay chain behavior.
 	pub relay_blocks_per_para_block: u32,
-	//TODO Make this optional
 	/// XCM messages and associated configuration information.
 	pub xcm_config: MockXcmConfig,
 	/// Inbound downward XCM messages to be injected into the block.
@@ -62,6 +61,7 @@ pub struct MockValidationDataInherentDataProvider {
 /// In addition to the messages themselves, some information about the parachain's
 /// configuration is also required so that the MQC heads can be read out of the
 /// parachain's storage, and the corresponding relay data mocked.
+#[derive(Default)]
 pub struct MockXcmConfig {
 	/// The parachain id of the parachain being mocked.
 	pub para_id: ParaId,

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -29,7 +29,7 @@ use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 /// relay_block_number = offset + relay_blocks_per_para_block * current_para_block
 /// To simulate a parachain that starts in relay block 1000 and gets a block in every other relay
 /// block, use 1000 and 2
-/// 
+///
 /// TODO Docs about the XCM injection
 pub struct MockValidationDataInherentDataProvider {
 	/// The current block number of the local block chain (the parachain)
@@ -54,8 +54,15 @@ impl InherentDataProvider for MockValidationDataInherentDataProvider {
 		inherent_data: &mut InherentData,
 	) -> Result<(), sp_inherents::Error> {
 		// Use the "sproof" (spoof proof) builder to build valid mock state root and proof.
-		let (relay_storage_root, proof) =
-			RelayStateSproofBuilder::default().into_state_root_and_proof();
+		let mut sproof_builder = RelayStateSproofBuilder::default();
+		println!("initial head: {:?}", sproof_builder.dmq_mqc_head);
+		// TODO This hash is copied from the log just to see if this approach works
+		// at all. I'll need to actually build the mcq_chain to do this properly.
+		sproof_builder.dmq_mqc_head = Some(sp_core::H256::from(hex_literal::hex!(
+			"3aa68593568d161595300df95c6164c11c6ce7c2ddd7ae816d8220e9273b555a"
+		)));
+		println!("modified head: {:?}", sproof_builder.dmq_mqc_head);
+		let (relay_storage_root, proof) = sproof_builder.into_state_root_and_proof();
 
 		// Calculate the mocked relay block based on the current para block
 		let relay_parent_number =

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -15,7 +15,7 @@
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{ParachainInherentData, INHERENT_IDENTIFIER};
-use cumulus_primitives_core::{InboundDownwardMessage, PersistedValidationData};
+use cumulus_primitives_core::{InboundDownwardMessage, PersistedValidationData, ParaId};
 use sp_inherents::{InherentData, InherentDataProvider};
 
 use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
@@ -32,6 +32,10 @@ use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 ///
 /// TODO Docs about the XCM injection
 pub struct MockValidationDataInherentDataProvider {
+	/// The parachain id of the parachain being mocked.
+	/// This field is only important if xcm is being used.
+	/// If you are not interested in injecting simulated XCM message, you ca nuse any value
+	pub para_id: ParaId,
 	/// The current block number of the local block chain (the parachain)
 	pub current_para_block: u32,
 	/// The relay block in which this parachain appeared to start. This will be the relay block
@@ -55,13 +59,14 @@ impl InherentDataProvider for MockValidationDataInherentDataProvider {
 	) -> Result<(), sp_inherents::Error> {
 		// Use the "sproof" (spoof proof) builder to build valid mock state root and proof.
 		let mut sproof_builder = RelayStateSproofBuilder::default();
+		// Set the sproof builder up to match the runtime
+		sproof_builder.para_id = self.para_id;
 		println!("initial head: {:?}", sproof_builder.dmq_mqc_head);
-		// TODO This hash is copied from the log just to see if this approach works
-		// at all. I'll need to actually build the mcq_chain to do this properly.
+		// TODO Eventually I'll need to actually build the mcq_chain to do this properly.
 		sproof_builder.dmq_mqc_head = Some(sp_core::H256::from(hex_literal::hex!(
-			"3aa68593568d161595300df95c6164c11c6ce7c2ddd7ae816d8220e9273b555a"
+			"6bc623c33c8aef0262bd9f9de1b18c3231f2ca48504d89a923953518d2bf2a44"
 		)));
-		println!("modified head: {:?}", sproof_builder.dmq_mqc_head);
+
 		let (relay_storage_root, proof) = sproof_builder.into_state_root_and_proof();
 
 		// Calculate the mocked relay block based on the current para block

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -159,10 +159,10 @@ impl InherentDataProvider for MockValidationDataInherentDataProvider {
 			match horizontal_messages.get_mut(para_id) {
 				Some(msgs) => {
 					msgs.push(wrapped);
-				}
+				},
 				None => {
 					horizontal_messages.insert(*para_id, vec![wrapped]);
-				}
+				},
 			}
 		}
 

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -15,7 +15,7 @@
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{ParachainInherentData, INHERENT_IDENTIFIER};
-use cumulus_primitives_core::PersistedValidationData;
+use cumulus_primitives_core::{InboundDownwardMessage, PersistedValidationData};
 use sp_inherents::{InherentData, InherentDataProvider};
 
 use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
@@ -29,6 +29,8 @@ use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 /// relay_block_number = offset + relay_blocks_per_para_block * current_para_block
 /// To simulate a parachain that starts in relay block 1000 and gets a block in every other relay
 /// block, use 1000 and 2
+/// 
+/// TODO Docs about the XCM injection
 pub struct MockValidationDataInherentDataProvider {
 	/// The current block number of the local block chain (the parachain)
 	pub current_para_block: u32,
@@ -38,6 +40,11 @@ pub struct MockValidationDataInherentDataProvider {
 	/// The number of relay blocks that elapses between each parablock. Probably set this to 1 or 2
 	/// to simulate optimistic or realistic relay chain behavior.
 	pub relay_blocks_per_para_block: u32,
+	/// Inbound downward XCM messages to be injected into the block.
+	pub downward_messages: Vec<InboundDownwardMessage>,
+	//TODO also support horizontal messages, but let's fous on downward for PoC phase.
+	// Inbound Horizontal messages sorted by channel
+	// pub horizontal_messages: BTreeMap<ParaId, Vec<InboundHrmpMessage>>
 }
 
 #[async_trait::async_trait]
@@ -61,7 +68,7 @@ impl InherentDataProvider for MockValidationDataInherentDataProvider {
 				relay_parent_number,
 				max_pov_size: Default::default(),
 			},
-			downward_messages: Default::default(),
+			downward_messages: self.downward_messages.clone(),
 			horizontal_messages: Default::default(),
 			relay_chain_state: proof,
 		};

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -64,20 +64,32 @@ pub struct MockXcmConfig {
 	pub starting_hrmp_mqc_heads: BTreeMap<ParaId, relay_chain::Hash>,
 }
 
+/// The same string name that is used for the parachain system pallet in the
+/// runtime. The parachain template, and many other popular chains use `ParachainSystem`,
+/// and a corresponding `Default` implementation of this type exists.
+pub struct ParachainSystemName(pub &'static [u8]);
+
+impl Default for ParachainSystemName {
+	fn default() -> Self {
+		Self(b"ParachainSystem")
+	}
+}
+
 impl MockXcmConfig {
-	/// Utility method for creating a MockXcmConfig by reading the mqc_heads directly
-	/// from the storage of a previous block at common storage keys.
-	pub fn from_standard_storage<B: Block, BE: Backend<B>, C: StorageProvider<B, BE>>(
+	/// Create a MockXcmConfig by reading the mqc_heads directly
+	/// from the storage of a previous block.
+	pub fn new<B: Block, BE: Backend<B>, C: StorageProvider<B, BE>>(
 		client: &C,
 		parent_block: B::Hash,
 		para_id: ParaId,
+		parachain_system_name: ParachainSystemName,
 	) -> Self {
 
 		let starting_dmq_mqc_head = client
 			.storage(
 				&BlockId::Hash(parent_block),
 				&sp_storage::StorageKey(
-					[twox_128(b"ParachainSystem"), twox_128(b"LastDmqMqcHead")].concat().to_vec(),
+					[twox_128(parachain_system_name.0), twox_128(b"LastDmqMqcHead")].concat().to_vec(),
 				),
 			)
 			.expect("We should be able to read storage from the parent block.")


### PR DESCRIPTION
This Hotfix represents us merging https://github.com/paritytech/cumulus/pull/772 into our hotfix branch before it is accepted upstream.

This change will probably be available in stock cumulus in the `polkadot-v0.9.14` or `polkadot-v0.9.15` release. Until then, we will keep it as a hotfix.

However, this hotfix can be replaced with a direct cherry-picking from `master` once this work is merged upstream.